### PR TITLE
Feature: engine field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1285,6 +1285,19 @@
         "supports-color": "2.0.0"
       }
     },
+    "check-node-version": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-2.1.0.tgz",
+      "integrity": "sha1-hVZYQs95oJ36jiZnIFde4K7BmD0=",
+      "requires": {
+        "map-values": "1.0.1",
+        "minimist": "1.2.0",
+        "object-filter": "1.0.2",
+        "object.assign": "4.0.4",
+        "run-parallel": "1.1.6",
+        "semver": "5.4.1"
+      }
+    },
     "chip.avr.avr109": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/chip.avr.avr109/-/chip.avr.avr109-1.1.0.tgz",
@@ -4396,6 +4409,11 @@
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
+    "map-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
+      "integrity": "sha1-douOecAJvytk/ugG4ip7HEGQyZA="
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
@@ -4749,6 +4767,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-filter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
+      "integrity": "sha1-rwt5f/6+r4pSxmN87b6IFs/sG8g="
     },
     "object-keys": {
       "version": "1.0.11",
@@ -6095,6 +6118,11 @@
       "requires": {
         "is-promise": "2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
+      "integrity": "sha1-KQA8miFj4B4tLfyQV18sbB1hoDk="
     },
     "rx": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "mongo:start": "mongod",
     "mongo:stop": "mongo admin --eval 'db.shutdownServer()' > /dev/null",
     "build:clean": "rimraf dist/client/static",
-    "dev": "npm run build:clean && nodemon --inspect index.js"
+    "dev": "check-node-version --package && npm run build:clean && nodemon --inspect index.js"
+  },
+  "engines": {
+    "node": ">8.0.0"
   },
   "dependencies": {
     "avr-pizza": "^0.3.5",
@@ -21,6 +24,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-2": "^6.11.0",
     "babel-register": "^6.9.0",
+    "check-node-version": "^2.1.0",
     "config": "^1.21.0",
     "hapi": "^13.4.1",
     "hapi-auth-cookie": "^6.1.1",


### PR DESCRIPTION
# What's new?
Small update in package.json. Running `npm run dev` will always check that current version of node is at least 8.0.0, since we are using the new awsome utility function `util.promisify` (came in Node 8.0.0), as well as async await. Also installed the version checker `check-node-version`, since running `npm install` only installs our applications _dependencies_. 